### PR TITLE
add description of published/unpublished status

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,0 +1,58 @@
+# Changelog
+
+---
+
+All notable changes to this project will be documented in this file.
+
+According to [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) , the `Unreleased` section serves the following purposes:
+
+-   People can see what changes they might expect in upcoming releases.
+-   At release time, you can move the `Unreleased` section changes into a new release version section.
+
+## Types of changes
+
+---
+
+-   `Added` for new features.
+-   `Changed` for changes in existing functionality.
+-   `Removed` for now removed features.
+-   `Fixed` for any bug fixes.
+-   `Security` in case of vulnerabilities.
+-   `Deprecated` for soon-to-be removed features.
+
+## Unreleased
+
+---
+
+### Added
+
+- [#21](https://github.com/FC4E-CAT/fc4e-cat-api/pull/21) - Create assessment_manual.
+- [#20](https://github.com/FC4E-CAT/fc4e-cat-api/pull/20) - add guidelines icon in documentation.
+- [#19](https://github.com/FC4E-CAT/fc4e-cat-api/pull/19) - add concepts of validations and assessments.
+- [#18](https://github.com/FC4E-CAT/fc4e-cat-api/pull/18) - Items / Users.
+- [#17](https://github.com/FC4E-CAT/fc4e-cat-api/pull/17) - AO-909 Update docusuarus to 3.x.
+- [#15](https://github.com/FC4E-CAT/fc4e-cat-api/pull/15) - Create api.md.
+- [#14](https://github.com/FC4E-CAT/fc4e-cat-api/pull/14) - CAT-112 FC4E-Compliance Assessment Toolkit API Check the API specification.
+- [#13](https://github.com/FC4E-CAT/fc4e-cat-api/pull/13) - CAT-112 FC4E-Compliance Assessment Toolkit API Check the API specification.
+- [#10](https://github.com/FC4E-CAT/fc4e-cat-api/pull/10) - αdd guides to fc4e cat documentation
+
+
+
+### Changed
+
+- [#12](https://github.com/FC4E-CAT/fc4e-cat-api/pull/12) remove more menu.
+
+
+## 1.0.0 - 2023-05-25
+
+---
+
+### Added
+
+-   [#7](https://github.com/FC4E-CAT/fc4e-cat-api/pull/7) - Update readme.
+-   [#6](https://github.com/FC4E-CAT/fc4e-cat-api/pull/6) - Create SECURITY.md.
+-   [#5](https://github.com/FC4E-CAT/fc4e-cat-api/pull/5) - Create CONTRIBUTING.md.
+-   [#4](https://github.com/FC4E-CAT/fc4e-cat-api/pull/4) - Create CODE_OF_CONDUCT.md.
+-   [#3](https://github.com/FC4E-CAT/fc4e-cat-api/pull/3) - Update intro.md.
+.   [#2](https://github.com/FC4E-CAT/fc4e-cat-api/pull/3) - Create Jenkinsfile.
+.   [#1](https://github.com/FC4E-CAT/fc4e-cat-api/pull/1) - CAT-12 Initialize doc site.

--- a/docs/admin_procedures/_category_.json
+++ b/docs/admin_procedures/_category_.json
@@ -1,6 +1,6 @@
 {
-    "label": "Appendix",
-    "position": 8,
+    "label": "Admin Guidelines",
+    "position": 7,
     "link": {
       "type": "generated-index"
     }

--- a/docs/admin_procedures/admin_guidelines.md
+++ b/docs/admin_procedures/admin_guidelines.md
@@ -1,0 +1,58 @@
+---
+id: admin_guidelines
+title: Publishing Motivations in CAT 
+sidebar_position: 1
+---
+
+## Publish Motivations in CAT 
+
+A motivation is initially considered to be  in an **UNPUBLISHED** status,during creation. This means that the administrator can add, update, or delete context in the motivation.
+The status can change if the administrator decides to **PUBLISHED** the motivation. By publishing the motivation, the administrator 
+declares that no further changes will be applied to the motivation's context. 
+
+FC4E CAT Service provides the **PUBLISH** feature at two levels:
+1. **Motivation** level - The administrator can choose to publish a motivation.
+2. **Motivation-actor relation** level. The administrator can choose to publish the relation between a motivation and an actor related to the motivation.
+
+- When publishing a motivation, all associated motivation-actor relations are also published, automatically.
+
+At both levels, if status is **PUBLISHED add/update/delete** actions on the motivation's context are not permitted. Also, the following elements: metrics, criteria, principles, tests, test methods, and test definitions, also are not permitted to be updated or deleted, if they are part of a published motivation or motivation-actor relation.
+
+Additionaly, when a motivation is is an **UNPUBLISHED** status, only administrator can view of the motivation's template. Unpublished motivation's template view is not permitted to the users.
+
+### Actions Not Permitted in PUBLISHED Motivation or Motivation-Actor Relation
+
+| Action | API Request |
+|--------|-------------|
+| Update an existing Motivation | `PATCH v1/registry/motivations/{id}` |
+| Assign Actors to Motivation | `POST v1/registry/motivations/{id}/actors` |
+| Remove an Actor from a Motivation | `DELETE v1/registry/motivations/{id}/actors/{actor-id}` |
+| Update Criterion Item to Motivation Actor | `PUT v1/registry/motivations/{id}/actors/{actor-id}/criteria` |
+| Add Criterion Item to Motivation Actor | `POST v1/registry/motivations/{id}/actors/{actor-id}/criteria` |
+| Assign Principles to Motivation | `POST v1/registry/motivations/{id}/principles` |
+| Update an existing relationship between motivations, principles, and criteria | `PUT v1/registry/motivations/{id}/principles-criteria` |
+| Create a new relationship between motivations, principles, and criteria | `PUT v1/registry/motivations/{id}/principles-criteria` |
+| Publish a motivation | `PUT v1/registry/motivations/{id}/publish` |
+| Publish a motivation actor relationship | `PUT v1/registry/motivations/{id}/actors/{actor-id}/publish` |
+| Update Metric | `PUT v1/registry/metrics/{id}` |
+| Delete Metric | `DELETE v1/registry/metrics/{id}` |
+| Update Principles | `PUT v1/registry/principles/{id}` |
+| Delete Principles | `DELETE v1/registry/principles/{id}` |
+| Update Criterion | `PUT v1/registry/criteria/{id}` |
+| Delete Criterion | `DELETE v1/registry/criteria/{id}` |
+| Update Test Definition | `PUT v1/registry/tests/test-definition/{id}` |
+| Delete Test Definition | `DELETE v1/registry/tests/test-definition/{id}` |
+| Update Test Method | `PUT v1/registry/tests/test-method/{id}` |
+| Delete Test Method | `DELETE v1/registry/tests/test-method/{id}` |
+| Update Test | `PUT v1/registry/tests/{id}` |
+| Delete Test | `DELETE v1/registry/tests/{id}` |
+| Retrieve registry template for a specific motivation and actor | `GET /v1/templates/by-motivation/{motivation-id}/by-actor/{actor-id}` |
+
+
+### Actions Not Permitted in UNPUBLISHED Motivation or Motivation-Actor Relation
+
+| Action | API Request |
+|--------|-------------|
+| Unpublish a motivation | `PUT v1/registry/motivations/{id}/unpublish` 
+| Unpublish a motivation actor relationship| `PUT v1/registry/motivations/{id}/actors/{actor-id}/unpublish` 
+| Retrieve registry template for a specific motivation and actor  | `GET v1/templates/by-motivation/{motivation-id}/by-actor/{actor-id}` |


### PR DESCRIPTION
Added a new admin tab in the menu sidebar , to define the admin guidelines.
As first step was added the description of the publish/unpublish permissions on the motivations